### PR TITLE
[nrf temphack]: setting `ZEPHYR_<MODULE_NAME>_KCONFIG` for NCS modules

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -256,6 +256,10 @@ class KconfigCheck(ComplianceTest):
         modules = [name for name in os.listdir(modules_dir) if
                    os.path.exists(os.path.join(modules_dir, name, 'Kconfig'))]
 
+        nrf_modules_dir = ZEPHYR_BASE + '/../nrf/modules'
+        nrf_modules = [name for name in os.listdir(nrf_modules_dir) if
+                       os.path.exists(os.path.join(nrf_modules_dir, name, 'Kconfig'))]
+
         with open(modules_file, 'r') as fp_module_file:
             content = fp_module_file.read()
 
@@ -264,6 +268,11 @@ class KconfigCheck(ComplianceTest):
                 fp_module_file.write("ZEPHYR_{}_KCONFIG = {}\n".format(
                     re.sub('[^a-zA-Z0-9]', '_', module).upper(),
                     modules_dir + '/' + module + '/Kconfig'
+                ))
+            for module in nrf_modules:
+                fp_module_file.write("ZEPHYR_{}_KCONFIG = {}\n".format(
+                    re.sub('[^a-zA-Z0-9]', '_', module).upper(),
+                    nrf_modules_dir + '/' + module + '/Kconfig'
                 ))
             fp_module_file.write(content)
 


### PR DESCRIPTION
This temphack sets `ZEPHYR_<MODULE_NAME>_KCONFIG` variable for each
Kconfig file discovered in `nrf/modules/<module>/Kconfig`.

This is a temphack to allow carefull consideration on the optimal
approach forward that will allow compliance_check.py to be used
downstream with custom module_ext_roots, and at the same time keep
current flexibility for module glue code handling intact.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>