### PR TITLE
[nrf fromtree]: scripts: compliance.py updated to support KconfigBasic

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -225,13 +225,14 @@ class KconfigCheck(ComplianceTest):
     doc = "See https://docs.zephyrproject.org/latest/guides/kconfig/index.html for more details."
     path_hint = ZEPHYR_BASE
 
-    def run(self):
+    def run(self, full=True):
         kconf = self.parse_kconfig()
 
         self.check_top_menu_not_too_long(kconf)
         self.check_no_pointless_menuconfigs(kconf)
         self.check_no_undef_within_kconfig(kconf)
-        self.check_no_undef_outside_kconfig(kconf)
+        if full:
+            self.check_no_undef_outside_kconfig(kconf)
 
     def get_modules(self, modules_file):
         """
@@ -462,7 +463,7 @@ https://docs.zephyrproject.org/latest/guides/kconfig/tips.html#menuconfig-symbol
         # Skip doc/releases, which often references removed symbols
         grep_stdout = git("grep", "--line-number", "-I", "--null",
                           "--perl-regexp", regex, "--", ":!/doc/releases",
-                          cwd=ZEPHYR_BASE)
+                          cwd=Path(GIT_TOP))
 
         # splitlines() supports various line terminators
         for grep_line in grep_stdout.splitlines():
@@ -577,6 +578,21 @@ UNDEF_KCONFIG_WHITELIST = {
     "USE_STDC_",
     "WHATEVER",
 }
+
+
+class KconfigBasicCheck(KconfigCheck, ComplianceTest):
+    """
+    Checks is we are introducing any new warnings/errors with Kconfig,
+    for example using undefiend Kconfig variables.
+    This runs the basic Kconfig test, which is checking only for undefined
+    references inside the Kconfig tree.
+    """
+    name = "KconfigBasic"
+    doc = "See https://docs.zephyrproject.org/latest/guides/kconfig/index.html for more details."
+    path_hint = ZEPHYR_BASE
+
+    def run(self):
+        super().run(full=False)
 
 
 class Codeowners(ComplianceTest):


### PR DESCRIPTION
This commit lets the Kconfig compliance check run from top of current
git repo instead of only executing inside ZEPHYR_BASE.
This extends the usability of the Kconfig compliance check.

Together with this possibility, a KconfigBasic mode has been added which
will execute the same verification for symbols in the Kconfig tree but
will not check for undefined symbols outside Kconfig.

This is needed as running Kconfig undef check outside the tree in
non-Zephyr repos might pickup `CONFIG_` named symbols in other code.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-------

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/31712
